### PR TITLE
Add setup-globals script to index.html

### DIFF
--- a/lessons/06-verify-custom-javascript-tests-with-jest/index.html
+++ b/lessons/06-verify-custom-javascript-tests-with-jest/index.html
@@ -8,7 +8,7 @@
 <body>
 	<div id="app"></div>
 	<p>Look in console.</p>
+	<script src="./setup-globals.js"></script>
 	<script src="./jest.test.js"></script>
 </body>
-
 </html>


### PR DESCRIPTION
# Bug Fix
CodeSandbox embed is broken due to no reference to `setup-globals.js` in `index.html`. 

Affected lesson: [Verify Custom JavaScript Tests with Jest](https://testingjavascript.com/lessons/jest-verify-custom-javascript-tests-with-jest)

![Codesandbox embed shows an empty square](https://user-images.githubusercontent.com/6188161/72080317-943c8c00-32ca-11ea-97e2-b57aba1f9d43.png)

## Changes made
- add script tag in `06-verify-custom-javascript-tests-with-jest` `index.html` referencing `setup-globals.js`

[Working code example](https://codesandbox.io/s/github/zacjones93/js-testing-fundamentals/tree/egghead-2018/lessons/06-verify-custom-javascript-tests-with-jest)

![](https://media3.giphy.com/media/10LKovKon8DENq/giphy.gif?cid=5a38a5a2570d666712207b6785e5a23c1e5b5b55745e1dc2&rid=giphy.gif)

