### PR TITLE
Change master to main in comments and contributing page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,20 +11,20 @@ series [How to Contribute to an Open Source Project on GitHub][egghead]
 2.  Run `npm run setup -s` to install dependencies and run validation
 3.  Create a branch for your PR with `git checkout -b pr/your-branch-name`
 
-> Tip: Keep your `master` branch pointing at the original repository and make
+> Tip: Keep your `main` branch pointing at the original repository and make
 > pull requests from branches on your fork. To do this, run:
 >
 > ```
 > git remote add upstream https://github.com/kentcdodds/js-testing-fundamentals.git
 > git fetch upstream
-> git branch --set-upstream-to=upstream/master master
+> git branch --set-upstream-to=upstream/main main
 > ```
 >
 > This will add the original repository as a "remote" called "upstream," Then
-> fetch the git information from that remote, then set your local `master`
-> branch to use the upstream master branch whenever you run `git pull`. Then you
-> can make all of your pull request branches based on this `master` branch.
-> Whenever you want to update your version of `master`, do a regular `git pull`.
+> fetch the git information from that remote, then set your local `main`
+> branch to use the upstream main branch whenever you run `git pull`. Then you
+> can make all of your pull request branches based on this `main` branch.
+> Whenever you want to update your version of `main`, do a regular `git pull`.
 
 ## Help needed
 

--- a/lessons/assertion-library.js
+++ b/lessons/assertion-library.js
@@ -29,5 +29,5 @@ expected = 4
 expect(result).toBe(expected)
 
 /**
- * Answer: Checkout the master branch for the answer.
+ * Answer: Checkout the main branch for the answer.
  */

--- a/lessons/async-await.js
+++ b/lessons/async-await.js
@@ -30,5 +30,5 @@ test('subtractAsync subtracts numbers asynchronously', () => {
 })
 
 /**
- * Answer: Checkout the master branch for the answer.
+ * Answer: Checkout the main branch for the answer.
  */

--- a/lessons/globals.js
+++ b/lessons/globals.js
@@ -32,5 +32,5 @@ test('subtractAsync subtracts numbers asynchronously', async () => {
 /**
  * Hint: https://nodejs.org/api/globals.html#globals_global
  *
- * Answer: Checkout the master branch for the answer.
+ * Answer: Checkout the main branch for the answer.
  */

--- a/lessons/simple.js
+++ b/lessons/simple.js
@@ -18,5 +18,5 @@ let result, expected
 /**
  * Hint: there's no magic, just the most straightforward conditional statement.
  *
- * Answer: Checkout the master branch for the answer.
+ * Answer: Checkout the main branch for the answer.
  */

--- a/lessons/testing-framework.js
+++ b/lessons/testing-framework.js
@@ -31,5 +31,5 @@ test('subtract subtracts numbers', () => {
 })
 
 /**
- * Answer: Checkout the master branch for the answer.
+ * Answer: Checkout the main branch for the answer.
  */


### PR DESCRIPTION
Hi there! It looks like you've changed your default branch from `master` to `main` and this PR updates the contributing doc as well as all inline comments to reflect that. 

May seem like a small change but this actually causes some of the instructions in `CONTRIBUTING.md` to break with `fatal: branch 'master' does not exist`. 

Thanks for the awesome course, really enjoying it so far!