### PR TITLE
changed wording from master to main in the contributing.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,20 +11,20 @@ series [How to Contribute to an Open Source Project on GitHub][egghead]
 2.  Run `npm run setup -s` to install dependencies and run validation
 3.  Create a branch for your PR with `git checkout -b pr/your-branch-name`
 
-> Tip: Keep your `master` branch pointing at the original repository and make
+> Tip: Keep your `main` branch pointing at the original repository and make
 > pull requests from branches on your fork. To do this, run:
 >
 > ```
 > git remote add upstream https://github.com/kentcdodds/js-testing-fundamentals.git
 > git fetch upstream
-> git branch --set-upstream-to=upstream/master master
+> git branch --set-upstream-to=upstream/main main
 > ```
 >
 > This will add the original repository as a "remote" called "upstream," Then
-> fetch the git information from that remote, then set your local `master`
-> branch to use the upstream master branch whenever you run `git pull`. Then you
-> can make all of your pull request branches based on this `master` branch.
-> Whenever you want to update your version of `master`, do a regular `git pull`.
+> fetch the git information from that remote, then set your local `main`
+> branch to use the upstream main branch whenever you run `git pull`. Then you
+> can make all of your pull request branches based on this `main` branch.
+> Whenever you want to update your version of `main`, do a regular `git pull`.
 
 ## Help needed
 


### PR DESCRIPTION
Hey Kent, 

I recently bought your testing js course and I was configuring my repo when I encountered the use of "master" as default branch in the description but the branches are already called main. (or is it just on my machine because I use main as default branch ?)

I simple propose to change the wording in the docs from master to main to remove that one pitfall while setting up the project.




